### PR TITLE
Support for multiple encodings

### DIFF
--- a/src/netcatgui.cpp
+++ b/src/netcatgui.cpp
@@ -31,6 +31,13 @@ NetcatGUI::NetcatGUI(QWidget *parent)
     ui->mainToolBar->addAction(newListen);
     ui->mainToolBar->addAction(saveLog);
 
+    encodingGroup = new QActionGroup(this);
+    encodingGroup->addAction(ui->actionEncodingLatin1);
+    encodingGroup->addAction(ui->actionEncodingUTF8);
+    encodingGroup->addAction(ui->actionEncodingSystem);
+
+    ui->actionEncodingUTF8->setChecked(true);
+
     QObject::connect(newListen, SIGNAL(triggered()), this, SLOT(ncAddNewListenTab()));
     QObject::connect(newConnect, SIGNAL(triggered()), this, SLOT(ncAddNewConnectTab()));
     QObject::connect(saveLog, SIGNAL(triggered()), this, SLOT(ncSaveLog()));
@@ -51,6 +58,8 @@ NetcatGUI::NetcatGUI(QWidget *parent)
     QObject::connect(ui->actionSend, SIGNAL(triggered()), this, SLOT(ncSend()));
 
     QObject::connect(ui->actionEnd_Messages_with_new_line, SIGNAL(triggered(bool)), this, SLOT(ncEndMessagesNewLineTriggered(bool)));
+
+    QObject::connect(encodingGroup, SIGNAL(triggered(QAction*)), this, SLOT(ncEncodingTriggered(QAction*)));
 
     QObject::connect(ui->tabWidget, SIGNAL(tabCloseRequested(int)), this, SLOT(ncTabCloseRequest(int)));
     QObject::connect(ui->tabWidget, SIGNAL(currentChanged(int)), this, SLOT(ncCurrentTabChanged(int)));
@@ -150,6 +159,21 @@ void NetcatGUI::ncEndMessagesNewLineTriggered(bool checked)
     for(int i = 0; i < ui->tabWidget->count(); i++)
         static_cast<NcSessionWidget*>(ui->tabWidget->currentWidget())->updateEndMessagesWithNewLine(checked);
 
+}
+
+void NetcatGUI::ncEncodingTriggered(QAction* action)
+{
+    auto encoding = NcSessionWidget::Utf8;
+
+    if (action == ui->actionEncodingLatin1)
+        encoding = NcSessionWidget::Latin1;
+    else if (action == ui->actionEncodingUTF8)
+        encoding = NcSessionWidget::Utf8;
+    else if (action == ui->actionEncodingSystem)
+        encoding = NcSessionWidget::System;
+
+    for(int i = 0; i < ui->tabWidget->count(); i++)
+        static_cast<NcSessionWidget*>(ui->tabWidget->currentWidget())->updateTextEncoding(encoding);
 }
 
 void NetcatGUI::ncAbout()

--- a/src/netcatgui.h
+++ b/src/netcatgui.h
@@ -4,6 +4,7 @@
 #include "widgets/ncsessionwidget.h"
 
 #include <QMainWindow>
+#include <QActionGroup>
 
 namespace Ui
 {
@@ -21,6 +22,7 @@ public:
 private:
     Ui::NetcatGUI *ui;
     QWidget *currentTab;
+    QActionGroup* encodingGroup;
 
 private slots:
     void ncAddNewListenTab();
@@ -32,6 +34,7 @@ private slots:
     void ncDisconnect();
     void ncSend();
     void ncEndMessagesNewLineTriggered(bool checked);
+    void ncEncodingTriggered(QAction* action);
     void ncCurrentTabChanged(int i);
     void ncupdateTabStatus();
     void ncSaveLog();

--- a/src/netcatgui.ui
+++ b/src/netcatgui.ui
@@ -14,7 +14,7 @@
    <string>NetcatGUI</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="resources.qrc">
+   <iconset resource="../resources/resources.qrc">
     <normaloff>:/toolbar/icons/connect.png</normaloff>:/toolbar/icons/connect.png</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -22,7 +22,16 @@
     <property name="spacing">
      <number>0</number>
     </property>
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item>
@@ -91,11 +100,20 @@
     <property name="title">
      <string>&amp;Session</string>
     </property>
+    <widget class="QMenu" name="menuEncoding">
+     <property name="title">
+      <string>Encoding</string>
+     </property>
+     <addaction name="actionEncodingLatin1"/>
+     <addaction name="actionEncodingUTF8"/>
+     <addaction name="actionEncodingSystem"/>
+    </widget>
     <addaction name="actionConnect"/>
     <addaction name="actionDisconnect"/>
     <addaction name="actionSend"/>
     <addaction name="separator"/>
     <addaction name="actionEnd_Messages_with_new_line"/>
+    <addaction name="menuEncoding"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
@@ -123,7 +141,7 @@
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionSave_Log">
    <property name="icon">
-    <iconset resource="resources.qrc">
+    <iconset resource="../resources/resources.qrc">
      <normaloff>:/toolbar/icons/save.png</normaloff>:/toolbar/icons/save.png</iconset>
    </property>
    <property name="text">
@@ -205,7 +223,7 @@
   </action>
   <action name="actionNew_Listen_Tab">
    <property name="icon">
-    <iconset resource="resources.qrc">
+    <iconset resource="../resources/resources.qrc">
      <normaloff>:/toolbar/icons/listen.png</normaloff>:/toolbar/icons/listen.png</iconset>
    </property>
    <property name="text">
@@ -244,7 +262,7 @@
   </action>
   <action name="actionNew_Connect_Tab">
    <property name="icon">
-    <iconset resource="resources.qrc">
+    <iconset resource="../resources/resources.qrc">
      <normaloff>:/toolbar/icons/connect.png</normaloff>:/toolbar/icons/connect.png</iconset>
    </property>
    <property name="text">
@@ -286,10 +304,34 @@
     <string>&amp;End Messages with CRLF</string>
    </property>
   </action>
+  <action name="actionEncodingLatin1">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Latin-1 (ISO 8859-1)</string>
+   </property>
+  </action>
+  <action name="actionEncodingUTF8">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>UTF-8</string>
+   </property>
+  </action>
+  <action name="actionEncodingSystem">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>System</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <resources>
-  <include location="resources.qrc"/>
+  <include location="../resources/resources.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/widgets/ncsessionconnectwidget.cpp
+++ b/src/widgets/ncsessionconnectwidget.cpp
@@ -135,7 +135,19 @@ void NcSessionConnectWidget::sendMessageToHost()
     if(!message.isEmpty()) {
         if(getEndMessagesWithNewLine())
             message.append("\n");
-        hostConnection.write(message.toLatin1());
+        QByteArray messageData;
+        switch (getTextEncoding()) {
+        case Latin1:
+            messageData = message.toLatin1();
+            break;
+        case Utf8:
+            messageData = message.toUtf8();
+            break;
+        case System:
+            messageData = message.toLocal8Bit();
+            break;
+        }
+        hostConnection.write(messageData);
     }
     ui->userInputPlainTextEdit->clear();
 }

--- a/src/widgets/ncsessionlistenwidget.cpp
+++ b/src/widgets/ncsessionlistenwidget.cpp
@@ -160,7 +160,19 @@ void NcSessionListenWidget::sendMessageToClient()
     if(!message.isEmpty()){
         if(getEndMessagesWithNewLine())
             message.append("\n");
-        hostConnection->write(message.toLatin1());
+        QByteArray messageData;
+        switch (getTextEncoding()) {
+        case Latin1:
+            messageData = message.toLatin1();
+            break;
+        case Utf8:
+            messageData = message.toUtf8();
+            break;
+        case System:
+            messageData = message.toLocal8Bit();
+            break;
+        }
+        hostConnection->write(messageData);
     }
     ui->userInputPlainTextEdit->clear();
 }

--- a/src/widgets/ncsessionwidget.cpp
+++ b/src/widgets/ncsessionwidget.cpp
@@ -1,7 +1,7 @@
 #include "ncsessionwidget.h"
 
-NcSessionWidget::NcSessionWidget(QWidget *parent, bool EndMessagesWithNewLine)
-    : ui(new Ui::NcSessionWidget), end_messages_with_newline(EndMessagesWithNewLine)
+NcSessionWidget::NcSessionWidget(QWidget *parent, bool EndMessagesWithNewLine, Encoding encoding)
+    : ui(new Ui::NcSessionWidget), end_messages_with_newline(EndMessagesWithNewLine), text_encoding(encoding)
 {
     ui->setupUi(this);
     ui->sendButton->setEnabled(false);
@@ -19,9 +19,19 @@ void NcSessionWidget::updateEndMessagesWithNewLine(bool checked)
     end_messages_with_newline = checked;
 }
 
+void NcSessionWidget::updateTextEncoding(Encoding encoding)
+{
+    text_encoding = encoding;
+}
+
 bool NcSessionWidget::getEndMessagesWithNewLine()
 {
     return end_messages_with_newline;
+}
+
+NcSessionWidget::Encoding NcSessionWidget::getTextEncoding()
+{
+    return text_encoding;
 }
 
 QString NcSessionWidget::getStatusMessage()

--- a/src/widgets/ncsessionwidget.h
+++ b/src/widgets/ncsessionwidget.h
@@ -14,7 +14,14 @@ class NcSessionWidget : public QWidget
     Q_OBJECT
 
 public:
-    NcSessionWidget(QWidget *parent = 0, bool EndMessagesWithNewLine = false);
+    enum Encoding
+    {
+        Latin1,
+        Utf8,
+        System
+    };
+
+    NcSessionWidget(QWidget *parent = 0, bool EndMessagesWithNewLine = false, Encoding encoding = Utf8);
     ~NcSessionWidget();
     QString getStatusMessage();
     QString getSessionName();
@@ -23,7 +30,9 @@ public:
     void paste();
     void copy();
     void updateEndMessagesWithNewLine(bool checked);
+    void updateTextEncoding(Encoding encoding);
     bool getEndMessagesWithNewLine();
+    Encoding getTextEncoding();
 
 public slots:
     virtual void Connect();
@@ -45,6 +54,7 @@ private:
     QString statusMessage;
 
     bool    end_messages_with_newline;
+    Encoding text_encoding;
 };
 
 #endif // NC_SESSION_WIDGET_H


### PR DESCRIPTION
Hi,
I've added support for choosing the preferred text encoding for messages (defaults to UTF-8 now).
There's a new menu in the session tab where you can pick between Latin-1, UTF-8 and the system local encoding.

Thanks for making such a useful tool!