### PR TITLE
Made it compatible with Qt6 + signal fix

### DIFF
--- a/src/netcatgui.cpp
+++ b/src/netcatgui.cpp
@@ -9,6 +9,7 @@
 #include <QAction>
 #include <QMessageBox>
 #include <QFileDialog>
+#include <QLocale>
 #include <QTime>
 #include <QIcon>
 
@@ -235,7 +236,7 @@ void NetcatGUI::ncSaveLog()
         QMessageBox::critical(this, "File open error", "The selected file could not be opened for writing.\n Log not saved.");
         return;
     }
-    QString log = "--\n[" + QTime::currentTime().toString(Qt::SystemLocaleShortDate) + " " + QDate::currentDate().toString(Qt::SystemLocaleShortDate)
+    QString log = "--\n[" + QLocale().toString(QTime::currentTime(),QLocale::ShortFormat) + " " + QLocale().toString(QDate::currentDate(),QLocale::ShortFormat)
                   + "]" + "\nNetcatGUI log session for " + static_cast<NcSessionWidget*>(ui->tabWidget->currentWidget())->getSessionName() + "\n---\n" + static_cast<NcSessionWidget*>(ui->tabWidget->currentWidget())->getSessionLog().toLatin1() + "\n-----";
     qint64 bytesWritten = logFile.write(log.toLatin1());
     if( bytesWritten ==  -1)

--- a/src/widgets/ncsessionconnectwidget.cpp
+++ b/src/widgets/ncsessionconnectwidget.cpp
@@ -21,7 +21,7 @@ NcSessionConnectWidget::NcSessionConnectWidget(QWidget *parent, bool EndMessages
     QObject::connect(ui->sendButton, SIGNAL(clicked()), this, SLOT(sendMessageToHost()));
     /*host connection setup*/
     QObject::connect(&hostConnection, SIGNAL(connected()), this, SLOT(connectSuccess()));
-    QObject::connect(&hostConnection, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(connectFailure(QAbstractSocket::SocketError)));
+    QObject::connect(&hostConnection, SIGNAL(errorOccured(QAbstractSocket::SocketError)), this, SLOT(connectFailure(QAbstractSocket::SocketError)));
     QObject::connect(&hostConnection, SIGNAL(readyRead()), this, SLOT(connectionDataAvailable()));
 }
 

--- a/src/widgets/ncsessionlistenwidget.cpp
+++ b/src/widgets/ncsessionlistenwidget.cpp
@@ -137,7 +137,7 @@ void NcSessionListenWidget::acceptConnection()
 {
     hostConnection = tcpListenServer.nextPendingConnection();
     QObject::connect(hostConnection, SIGNAL(readyRead()), this, SLOT(connectionDataAvailable()));
-    QObject::connect(hostConnection, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(hostConnectionError(QAbstractSocket::SocketError)));
+    QObject::connect(hostConnection, SIGNAL(errorOccurred(QAbstractSocket::SocketError)), this, SLOT(hostConnectionError(QAbstractSocket::SocketError)));
 
     setStatusMessage("Connected");
     emit statusChanged();

--- a/src/widgets/ncsessionwidget.cpp
+++ b/src/widgets/ncsessionwidget.cpp
@@ -45,6 +45,8 @@ QString NcSessionWidget::getTextEncodingName()
     case System:
         return tr("System");
     }
+
+    return "";
 }
 
 QString NcSessionWidget::getStatusMessage()


### PR DESCRIPTION
1. Qt::SystemLocaleShortDate is removed in Qt6 so replaced it with QLocale to make it compatible.
2. Fixed wrong signal name in a QObject::connect call. (replaced "error" with "errorOccurred")
3. Fixed "Control reaches the end of a non-void function" warning.